### PR TITLE
Wip on app management module

### DIFF
--- a/dbif/source/class/aiagallery/dbif/MApps.js
+++ b/dbif/source/class/aiagallery/dbif/MApps.js
@@ -38,15 +38,17 @@ qx.Mixin.define("aiagallery.dbif.MApps",
                          this.intersectKeywordAndQuery,
                          [ "queryArgs" ]);
 
-
     this.registerService("aiagallery.features.getAppListByList",
                          this.getAppListByList,
                          [ "uidArr", "requestedFields" ]);
-
     
     this.registerService("aiagallery.features.getAppInfo",
                          this.getAppInfo,
                          [ "uid", "bStringize", "requestedFields" ]);
+
+    this.registerService("aiagallery.features.mgmtEditApp",
+                         this.mgmtEditApp,
+                         [ "uid", "attributes" ]);
   },
 
   statics :
@@ -1013,7 +1015,552 @@ qx.Mixin.define("aiagallery.dbif.MApps",
       
       return appData;
     },
-    
+
+
+    mgmtEditApp : function(uid, attributes, error)
+    {
+
+// ** Edit me! **
+      var             i;
+      var             title;
+      var             description;
+      var             image;
+      var             previousAuthors;
+      var             source;
+      var             tags;
+      var             tagObj;
+      var             tagData;
+      var             oldTags;
+      var             bHasCategory;
+      var             categories;
+      var             uploadTime;
+      var             status;
+      var             statusIndex;
+      var             appData;
+      var             appObj;
+      var             hTask = null;
+      var             fTask = null;
+      var             queue;
+      var             options;
+      var             bNew;
+      var             whoami;
+      var             missing = [];
+      var             addedBlobs = [];
+      var             removeBlobs = [];
+      var             image1Key;
+      var             sourceKey = null;
+      var             field;
+          var             requestData;
+      var             messageData;
+      var             messageBus;
+      var             allowableFields =
+        [
+          "uid",
+          "title",
+          "description",
+          "image1",
+          "source",
+          "sourceFileName",
+          "tags"
+        ];
+      var             requiredFields =
+        [
+          "owner",
+          "title",
+          "description",
+          "tags",
+          "source",
+          "image1"
+        ];
+      
+      try
+      {
+        // Don't let the caller override the owner
+        delete attributes["owner"];
+
+        // Determine who the logged-in user is
+        whoami = this.getWhoAmI();
+
+        // Get an AppData object. If uid is non-null, retrieve the prior data.
+        appObj = new aiagallery.dbif.ObjAppData(uid);
+
+        // Retrieve the data
+        appData = appObj.getData();
+
+        // If we were given a record identifier...
+        if (uid !== null)
+        {
+          // ... it must have already existed or it's an error
+          if (appObj.getBrandNew())
+          {
+            // It didn't!
+            error.setCode(1);
+            error.setMessage("Unrecognized UID");
+            return error;
+          }
+
+          // Ensure that the logged-in user owns this application.
+          if (appData.owner != whoami.id)
+          {
+            // He doesn't. Someone's doing something nasty!
+            error.setCode(2);
+            error.setMessage("Not owner");
+            return error;
+          }
+        }
+        else
+        {
+          // Initialize the owner field
+          appData.owner = whoami.id;
+        }
+
+        // Set the application owner
+        attributes.owner = whoami.id;
+
+        // Issue a query for all category tags
+        categories = liberated.dbif.Entity.query("aiagallery.dbif.ObjTags", 
+                                                 {
+                                                   type  : "element",
+                                                   field : "type",
+                                                   value : "category"
+                                                 },
+                                                 null);
+
+        // We want to look at only the value field of each category
+        categories = categories.map(
+          function(o)
+          {
+            return o.value;
+          });
+
+        // Save the existing tags list
+        oldTags = appData.tags;
+
+        // Copy fields from the attributes parameter into this db record
+        allowableFields.forEach(
+          function(field)
+          {
+            // Was this field provided in the parameter attributes?
+            if (attributes[field])
+            {
+              // Handle source field specially
+              switch(field)
+              {
+              case "title":
+                // Validate the length
+                if (attributes.title.length > 
+                    aiagallery.dbif.Constants.FieldLength.Title)
+                {
+                  // The field data is too long
+                  error.setCode(3);
+                  error.setMessage("Field data too long");
+                  error.setData(
+                    {
+                      field  : "title",
+                      maxLen : aiagallery.dbif.Constants.FieldLength.Title
+                    });
+                  throw error;
+                }
+
+                // Replace what's in the db entry
+                appData[field] = attributes[field];
+                break;
+
+              case "description":
+                // Validate the length
+                if (attributes.description.length > 
+                    aiagallery.dbif.Constants.FieldLength.Description)
+                {
+                  // The field data is too long
+                  error.setCode(3);
+                  error.setMessage("Field data too long");
+                  error.setData(
+                    {
+                      field  : "description",
+                      maxLen : aiagallery.dbif.Constants.FieldLength.Description
+                    });
+                  throw error;
+                }
+
+                // Replace what's in the db entry
+                appData[field] = attributes[field];
+                break;
+
+              case "source":
+                // If there's no newsource member...
+                if (! appData.newsource)
+                {
+                  // ... then create it
+                  appData.newsource = [];
+                }
+                break;
+
+              case "image1":
+                // Ensure we have a data url
+                if (! qx.lang.Type.isString(attributes.image1) ||
+                    attributes.image1.substring(0, 5) != "data:")
+                {
+                  // The image is invalid. Let 'em know.
+                  error.setCode(4);
+                  error.setMessage("Invalid image data");
+                  throw error;
+                }
+
+                // Save the field data
+                appData.image1 = attributes.image1;
+
+                // Indicate that this file needs later processing.
+                appData.newimage1 = attributes.image1;
+                break;
+
+              case "tags":
+                // Validate the length
+                if (attributes.tags.length > 
+                    aiagallery.dbif.Constants.FieldLength.Tags)
+                {
+                  // The field data is too long
+                  error.setCode(3);
+                  error.setMessage("Field data too long");
+                  error.setData(
+                    {
+                      field  : "tags",
+                      maxLen : aiagallery.dbif.Constants.FieldLength.Tags
+                    });
+                  throw error;
+                }
+
+                // Replace what's in the db entry
+                appData.tags = attributes.tags;
+
+                // Ensure that at least one of the specified tags is a category
+                bHasCategory = false;
+                tags = appData.tags;
+                for (i = 0; i < tags.length; i++)
+                {
+                  // Is this tag a category?
+                  if (qx.lang.Array.contains(categories, tags[i]))
+                  {
+                    // Yup. Mark it.
+                    bHasCategory = true;
+
+                    // No need to look further.
+                    break;
+                  }
+                }
+                break;
+
+              default:
+                // Replace what's in the db entry
+                appData[field] = attributes[field];
+                break;
+              }
+            }
+          });
+
+        // If tags were specified, did we find at least one category tag?
+        if (attributes.tags && ! bHasCategory)
+        {
+          // Nope. Let 'em know.
+          error.setCode(5);
+          error.setMessage("At least one category is required");
+          return error;
+        }
+
+        // See if any fields are missing
+        for (field in
+             qx.lang.Object.getKeys(appObj.getDatabaseProperties().fields))
+        {
+          if (qx.lang.Array.contains(requiredFields, field) &&
+              typeof appData[field] == "undefined")
+          {
+            // Mark the required field as missing
+            missing.push(field);
+          }
+        }
+        
+        // Were there any missing, required fields?
+        if (missing.length > 0)
+        {
+          appData.status = aiagallery.dbif.Constants.Status.Incomplete;
+        }
+        else
+        {
+          appData.status = aiagallery.dbif.Constants.Status.Processing;
+        }
+
+        // If a new source file was uploaded...
+        if (attributes.source)
+        {
+          // ... then update the upload time to now
+          appData.uploadTime = aiagallery.dbif.MDbifCommon.currentTimestamp();
+
+          // Save the data
+          sourceKey = liberated.dbif.Entity.putBlob(attributes.source);
+
+          // Prepend the blob id to the key list of new source files
+          appData.source.unshift(sourceKey);
+
+          // Save the blob id to remove it, in case something fails
+          addedBlobs.push(sourceKey);
+        }
+      }
+      catch(e)
+      {
+        // Something failed. Remove any blobs we added.
+        addedBlobs.forEach(
+          function(blobId)
+          {
+            liberated.dbif.Entity.removeBlob(blobId);
+          });
+        
+        // Return or rethrow the error
+        if (e instanceof liberated.rpc.error.Error)
+        {
+          // It's a properly generated error, so return it
+          return e;
+        }
+        else
+        {
+          // Something unexpected
+          throw e;
+        }
+      }
+      
+      try
+      {
+        appData = liberated.dbif.Entity.asTransaction(
+          function()
+          {
+            // If tags were provided...
+            if (attributes.tags)
+            {
+              // Add new tags to the database, and update counts of formerly-
+              // existing tags. Remove "normal" tags with a count of 0.
+              appData.tags.forEach(
+                function(tag)
+                {
+                  // If the tag existed previously, ignore it.
+                  if (qx.lang.Array.contains(oldTags, tag))
+                  {
+                    // Remove it from oldTags
+                    qx.lang.Array.remove(oldTags, tag);
+                    return;
+                  }
+
+                  // It didn't exist. Create or retrieve existing tag.
+                  tagObj = new aiagallery.dbif.ObjTags(tag);
+                  tagData = tagObj.getData();
+
+                  // If we created it, data is initialized. Otherwise...
+                  if (! tagObj.getBrandNew())
+                  {
+                    // ... it existed, so we need to increment its count
+                    ++tagData.count;
+                  }
+
+                  // Save the tag object
+                  tagObj.put();
+                });
+
+              // Anything left in oldTags are those which were removed.
+              oldTags.forEach(
+                function(tag)
+                {
+                  tagObj = new aiagallery.dbif.ObjTags(tag);
+                  tagData = tagObj.getData();
+
+                  // The record has to exist already. Decrement this tag's
+                  // count.
+                  --tagData.count;
+
+                  // Ensure it's a "normal" tag
+                  if (tagData.type != "normal")
+                  {
+                    // It's not, so we have nothing more we need to do.
+                    return;
+                  }
+
+                  // If the count is less than 1...
+                  if (tagData.count < 1)
+                  {
+                    // ... then we can remove the tag
+                    tagObj.removeSelf();
+                  }
+                });
+            }
+
+            // Save this record in the database
+            appObj.put();
+
+            // If there were were missing fields...
+            if (appData.status != aiagallery.dbif.Constants.Status.Processing)
+            {
+              // ... then add a log entry so they know the app is incomplete
+              this.logMessage(appData.owner, "App incomplete", appData.title);
+
+              // Return partial data including newly-created key (if adding)
+              return appObj.getData();
+            }
+
+            // Add all words in text fields to word Search record
+            aiagallery.dbif.MApps._populateSearch(appObj.getData());
+
+            requestData =
+              {
+                type : "postAppUpload",
+                uid  : appData.uid
+              };
+
+            // If we're on App Engine...
+            switch (liberated.dbif.Entity.getCurrentDatabaseProvider())
+            {
+            case "appengine":
+              // ... then create a task to clean up the data for this app
+              var TaskQueue = Packages.com.google.appengine.api.taskqueue;
+              var Queue = TaskQueue.Queue;
+              var QueueFactory = TaskQueue.QueueFactory;
+              var TaskOptions = TaskQueue.TaskOptions;
+              var jsonRequest = qx.lang.Json.stringify(requestData);
+
+              queue = QueueFactory.getDefaultQueue();
+              options = TaskOptions.Builder.withUrl("/task");
+              options.payload(jsonRequest);
+              hTask = queue.add(options);
+              break;
+              
+            default:
+              fTask = qx.lang.Function.bind(
+                function(uid)
+                {
+                  var             appObj;
+                  var             appData;
+                  var             sourceBlobId;
+                  var             destBlobId;
+                  var             fileData;
+
+                  // Retrieve the app object
+                  appObj = new aiagallery.dbif.ObjAppData(requestData.uid);
+
+                  // Get the app property data from the app object
+                  appData = appObj.getData();
+
+                  // In the simulator we don't actually munge the data
+                  // urls. We can therefore just move them to their proper
+                  // resting place.
+                  if (appData.newimage1)
+                  {
+                    appData.image1 = appData.newimage1;
+                  }
+
+                  appData.newimage1 = null;
+
+                  // Post-processing is now complete.
+                  appData.status = aiagallery.dbif.Constants.Status.Active;
+
+                  // Write out the resulting data
+                  appObj.put();
+
+                  // Success
+                  this.logMessage(appData.owner,
+                                  "App available",
+                                  appData.title);
+
+                  // Dispatch a message for any subscribers to this type.
+                  // Don't do this in the build environment, because
+                  // TimerManager requires threads (in Rhino) which are
+                  // unavailable in App Engine.
+                  if (qx.core.Environment.get("qx.debug"))
+                  {
+                    qx.util.TimerManager.getInstance().start(
+                    function()
+                    {
+                      messageData =
+                        {
+                          type   : "app.postupload",
+                          title  : appData.title,
+                          appId  : appData.uid,
+                          status : appData.status
+                        };
+                      messageBus = qx.event.message.Bus.getInstance();
+                      messageBus.dispatchByName(messageData.type, messageData);
+                    },
+                    null,
+                    this,
+                    null,
+                    250);
+                  }
+
+                  // See if there are any source files to process.
+                  while (appData.newsource && appData.newsource.length > 0)
+                  {
+                     // There are. They were unshifted() onto their array, so
+                     // pop() them off to get them in FIFO order.
+                    sourceBlobId = appData.newsource.pop();
+
+                    // Retrieve the blob
+                    fileData = liberated.dbif.Entity.getBlob(sourceBlobId);
+
+                    // Decode the data
+                    fileData = aiagallery.dbif.Decoder64.decode(fileData);
+
+                    // Write it to a new blob
+                    destBlobId = liberated.dbif.Entity.putBlob(fileData);
+
+                    // Add the new blob id to the source blob list
+                    appData.source.unshift(destBlobId);
+
+                    // Remove the old blob
+                    liberated.dbif.Entity.removeBlob(sourceBlobId);
+                  }
+                },
+                this);
+              break;
+            }
+            
+            // Add a log entry so they know the app has been submitted
+            this.logMessage(appData.owner, "App submitted", appData.title);
+
+            // Return entity data including newly-created key (if adding)
+            return appObj.getData();
+          },
+          [],
+          this);
+      }
+      catch (e)
+      {
+        // The transaction failed. Remove any blobs we added.
+        addedBlobs.forEach(
+          function(blobId)
+          {
+            liberated.dbif.Entity.removeBlob(blobId);
+          });
+        
+        // If we had started the postprocessing task...
+        if (hTask !== null)
+        {
+          // ... then delete it
+          queue.deleteTask(hTask);
+        }
+
+        // Rethrow the error
+        throw e;
+      }
+      
+      // There was no error, so remove any old, no-longer-in-use blobs
+      removeBlobs.forEach(
+        function(blobId)
+        {
+          liberated.dbif.Entity.removeBlob(blobId);
+        });
+
+      // If we'd created a post-processing task, run it now
+      if (fTask)
+      {
+        fTask(appData.uid);
+      }
+      
+      return appData;
+    },
     
 
     deleteApp : function(uid, error)

--- a/dbif/source/class/aiagallery/dbif/MApps.js
+++ b/dbif/source/class/aiagallery/dbif/MApps.js
@@ -1050,72 +1050,51 @@ qx.Mixin.define("aiagallery.dbif.MApps",
       var             image1Key;
       var             sourceKey = null;
       var             field;
-          var             requestData;
+      var             requestData;
       var             messageData;
       var             messageBus;
+
+// Following needs tweaking
       var             allowableFields =
         [
-          "uid",
+//          "uid",                // ??
           "title",
           "description",
           "image1",
           "source",
           "sourceFileName",
-          "tags"
+          "tags",
+          "status"
         ];
       var             requiredFields =
         [
-          "owner",
+//          "owner",              // ??
           "title",
           "description",
-          "tags",
+          "image1",
           "source",
-          "image1"
+          "tags"
         ];
       
       try
       {
-        // Don't let the caller override the owner
-        delete attributes["owner"];
 
-        // Determine who the logged-in user is
-        whoami = this.getWhoAmI();
-
-        // Get an AppData object. If uid is non-null, retrieve the prior data.
+        // Get an App object for the given uid
         appObj = new aiagallery.dbif.ObjAppData(uid);
 
         // Retrieve the data
         appData = appObj.getData();
 
-        // If we were given a record identifier...
-        if (uid !== null)
-        {
-          // ... it must have already existed or it's an error
-          if (appObj.getBrandNew())
-          {
-            // It didn't!
-            error.setCode(1);
-            error.setMessage("Unrecognized UID");
-            return error;
-          }
+// Need to worry about authorization???
 
-          // Ensure that the logged-in user owns this application.
-          if (appData.owner != whoami.id)
-          {
-            // He doesn't. Someone's doing something nasty!
-            error.setCode(2);
-            error.setMessage("Not owner");
-            return error;
-          }
-        }
-        else
+        // Does the app exist?
+        if (appObj.getBrandNew())
         {
-          // Initialize the owner field
-          appData.owner = whoami.id;
+          // No--that's a problem!
+          error.setCode(1);
+          error.setMessage("Unrecognized UID");
+          return error;
         }
-
-        // Set the application owner
-        attributes.owner = whoami.id;
 
         // Issue a query for all category tags
         categories = liberated.dbif.Entity.query("aiagallery.dbif.ObjTags", 
@@ -1143,7 +1122,7 @@ qx.Mixin.define("aiagallery.dbif.MApps",
             // Was this field provided in the parameter attributes?
             if (attributes[field])
             {
-              // Handle source field specially
+              // Handle certain fields specially
               switch(field)
               {
               case "title":
@@ -1185,7 +1164,7 @@ qx.Mixin.define("aiagallery.dbif.MApps",
                 // Replace what's in the db entry
                 appData[field] = attributes[field];
                 break;
-
+/* // Hold off on this for now...
               case "source":
                 // If there's no newsource member...
                 if (! appData.newsource)
@@ -1194,7 +1173,8 @@ qx.Mixin.define("aiagallery.dbif.MApps",
                   appData.newsource = [];
                 }
                 break;
-
+*/
+/* // Hold off on this for now...
               case "image1":
                 // Ensure we have a data url
                 if (! qx.lang.Type.isString(attributes.image1) ||
@@ -1212,7 +1192,7 @@ qx.Mixin.define("aiagallery.dbif.MApps",
                 // Indicate that this file needs later processing.
                 appData.newimage1 = attributes.image1;
                 break;
-
+*/
               case "tags":
                 // Validate the length
                 if (attributes.tags.length > 
@@ -1287,7 +1267,7 @@ qx.Mixin.define("aiagallery.dbif.MApps",
         {
           appData.status = aiagallery.dbif.Constants.Status.Processing;
         }
-
+/*
         // If a new source file was uploaded...
         if (attributes.source)
         {
@@ -1303,6 +1283,7 @@ qx.Mixin.define("aiagallery.dbif.MApps",
           // Save the blob id to remove it, in case something fails
           addedBlobs.push(sourceKey);
         }
+*/
       }
       catch(e)
       {

--- a/frontend/aiagallery/source/class/aiagallery/module/mgmt/applications/Applications.js
+++ b/frontend/aiagallery/source/class/aiagallery/module/mgmt/applications/Applications.js
@@ -1,8 +1,8 @@
 /**
  * Copyright (c) 2011 Derrell Lipman
- * 
+ *
  * License:
- *   LGPL: http://www.gnu.org/licenses/lgpl.html 
+ *   LGPL: http://www.gnu.org/licenses/lgpl.html
  *   EPL : http://www.eclipse.org/org/documents/epl-v10.php
  */
 

--- a/frontend/aiagallery/source/class/aiagallery/module/mgmt/applications/CellEditorFactory.js
+++ b/frontend/aiagallery/source/class/aiagallery/module/mgmt/applications/CellEditorFactory.js
@@ -41,7 +41,6 @@ qx.Class.define("aiagallery.module.mgmt.applications.CellEditorFactory",
       // Error--no cellInfo! (shouldn't happen)
       {
 // INSERT ERROR CODE HERE!
-// ALSO REMOVE ADD APP CODE, IF ANY, FROM GUI AND FSM
       }
 
       // Cell editor layout

--- a/frontend/aiagallery/source/class/aiagallery/module/mgmt/applications/CellEditorFactory.js
+++ b/frontend/aiagallery/source/class/aiagallery/module/mgmt/applications/CellEditorFactory.js
@@ -1,4 +1,5 @@
 /**
+ *
  * Cell editor for all cells of the Users table
  *
  * Copyright (c) 2011 Derrell Lipman

--- a/frontend/aiagallery/source/class/aiagallery/module/mgmt/applications/CellEditorFactory.js
+++ b/frontend/aiagallery/source/class/aiagallery/module/mgmt/applications/CellEditorFactory.js
@@ -1,6 +1,5 @@
 /**
- *
- * Cell editor for all cells of the Users table
+ * Cell editor for all cells of the Applications table
  *
  * Copyright (c) 2011 Derrell Lipman
  *
@@ -28,35 +27,33 @@ qx.Class.define("aiagallery.module.mgmt.applications.CellEditorFactory",
       var             cellEditor;
       var             dataModel;
       var             rowData;
-      var             title;
+      var             windowTitle;
       var             fsm;
-      var             bEditing;
 
-      // If there's a cellInfo object provided, we're editing an existing
-      // app. Get the row data. Otherwise, we're adding a new app.
+      // Get row data of the app being edited from the cellInfo object
       if (cellInfo && cellInfo.row !== undefined)
       {
-        // We're editing. Get the current row data.
-        bEditing = true;
         dataModel = cellInfo.table.getTableModel();
-        rowData = dataModel.getRowData(cellInfo.row);
-        title = this.tr("Edit App: ") + rowData[0];
+        rowData = dataModel.getRowDataAsMap(cellInfo.row);
+        windowTitle = this.tr("Edit App: ") + rowData.title;
       }
       else
+      // Error--no cellInfo! (shouldn't happen)
       {
-        bEditing = false;
-        title = this.tr("Add New App");
-        rowData = [ "", "", "", "", "", "", "", "", "" ];
+// INSERT ERROR CODE HERE!
+// ALSO REMOVE ADD APP CODE, IF ANY, FROM GUI AND FSM
       }
 
-      var layout = new qx.ui.layout.Grid(9, 2);
+      // Cell editor layout
+// TWEAK ME!
+      var layout = new qx.ui.layout.Grid(3, 2);
       layout.setColumnAlign(0, "right", "top");
       layout.setColumnWidth(0, 80);
       layout.setColumnWidth(1, 400);
       layout.setSpacing(10);
 
-      // Create the cell editor window, since we need to return it immediately
-      cellEditor = new qx.ui.window.Window(title);
+      // Cell editor window
+      cellEditor = new qx.ui.window.Window(windowTitle);
       cellEditor.setLayout(layout);
       cellEditor.set(
         {
@@ -67,6 +64,8 @@ qx.Class.define("aiagallery.module.mgmt.applications.CellEditorFactory",
           showMinimize: false,
           padding : 10
         });
+      // Center on resize
+// NO EFFECT, AS FAR AS I CAN TELL
       cellEditor.addListener(
         "resize",
         function(e)
@@ -74,18 +73,14 @@ qx.Class.define("aiagallery.module.mgmt.applications.CellEditorFactory",
           this.center();
         });
 
-      // If we're editing, save the cell info.  We'll need it when the cell
-      // editor closes.
-      bEditing && cellEditor.setUserData("cellInfo", cellInfo);
+      // Save cell info, which will be needed when the cell editor closes.
+      cellEditor.setUserData("cellInfo", cellInfo);
 
-      // Add the form field labels
+      // Add form field labels
       i = 0;
-
       [
-        this.tr("DisplayName"),
-        this.tr("Email"),
-        this.tr("Permissions"),
-        this.tr("Status")
+        this.tr("Title"),
+        this.tr("Description")
       ].forEach(function(label)
         {
           o = new qx.ui.basic.Label(label);
@@ -97,116 +92,45 @@ qx.Class.define("aiagallery.module.mgmt.applications.CellEditorFactory",
           cellEditor.add(o, {row: i++, column : 0});
         });
 
-      // Create the editor field for the user name
-      var displayName = new qx.ui.form.TextField("");
-      displayName.setValue(rowData[0]);
-      cellEditor.add(displayName, { row : 0, column : 1 });
+      // Create the editor field for the app title
+      var titleField = new qx.ui.form.TextField("");
+      titleField.setValue(rowData.title);
+      cellEditor.add(titleField, { row : 0, column : 1 });
 
-      // Create the editor field for the email address
-      var email = new qx.ui.form.TextField("");
-      email.setValue(rowData[1]);
-      cellEditor.add(email, { row : 1, column : 1 });
-
-      // If we're editing, don't allow them to change the email (userId) value
-      bEditing && email.setEnabled(false);
-
-      // Create the editor field for permissions
-      var permissions = new qx.ui.form.List();
-      permissions.setHeight(140);
-      permissions.setSelectionMode("multi");
-
-      // Split the existing permissions so we can easily search for them
-      var permissionList = rowData[2].split(/ *, */);
-
-      // Add each of the permission values
-      qx.lang.Object.getKeys(aiagallery.dbif.Constants.Permissions).forEach(
-        function(perm)
-        {
-          // Pull the permission description into the variable description
-          var description = aiagallery.dbif.Constants.Permissions[perm];
-
-          // Create a ListItem with the permission name and description
-          var item = new qx.ui.form.ListItem(description + " (" + perm + ")");
-
-          // Set the internal name of the permission to equal the display name
-          item.setUserData("internal", perm);
-
-          // Set "description" in userdata of the permission to be the
-          // description of the permission.
-          item.setUserData("description", description);
-
-          // Create a tooltip that describes the permission, then attach it to
-          // the List Item
-          var tooltip = new qx.ui.tooltip.ToolTip(description);
-          item.setToolTip(tooltip);
-
-          // Add the list item with the attached tool tip to the list
-          permissions.add(item);
-
-          // Is this permission currently assigned to the user being edited?
-          if (qx.lang.Array.contains(permissionList, perm))
-          {
-            // Yup. Add it to the selection list
-            permissions.addToSelection(item);
-          }
-        });
-
-      cellEditor.add(permissions, { row : 2, column : 1 });
-
-      var status = new qx.ui.form.SelectBox();
-
-      // Add each of the status values by pulling the array from Constants.js
-      qx.lang.Object.getKeys(aiagallery.dbif.Constants.Status).forEach(
-        function(stat)
-        //[
-        //  { i8n: this.tr("Active"),  internal: "Active" },
-        //  { i8n: this.tr("Pending"), internal: "Pending" },
-        //  { i8n: this.tr("Banned"),  internal: "Banned" }
-        //].forEach(function(stat)
-        {
-          // Create a new list item with the current status' name
-          var item = new qx.ui.form.ListItem(stat);
-
-          // Set the internal name of the status to the display name for now
-          item.setUserData("internal", stat);
-
-          // Add this item to the selectbox
-          status.add(item);
-
-          // Is this the current status?
-          if (stat == rowData[3])
-          {
-            status.setSelection( [ item ] );
-          }
-        });
-
-      cellEditor.add(status, { row : 3, column : 1 });
+      // Create the editor field for the app description
+      var descriptionField = new qx.ui.form.TextField("");
+      descriptionField.setValue(rowData.description);
+      cellEditor.add(descriptionField, { row : 1, column : 1 });
 
       // Save the input fields for access by getCellEditorValue() and the FSM
-      cellEditor.setUserData("displayName", displayName);
-      cellEditor.setUserData("email", email);
-      cellEditor.setUserData("permissions", permissions);
-      cellEditor.setUserData("status", status);
+      cellEditor.setUserData("titleField", titleField);
+      cellEditor.setUserData("descriptionField", descriptionField);
+
+      // Save the uid
+      cellEditor.setUserData("uid", rowData.uid);
 
       // buttons
-      var paneLayout = new qx.ui.layout.HBox();
-      paneLayout.set(
+      var buttonLayout = new qx.ui.layout.HBox();
+      buttonLayout.set(
         {
           spacing: 4,
           alignX : "right"
         });
-      var buttonPane = new qx.ui.container.Composite(paneLayout);
+      var buttonPane = new qx.ui.container.Composite(buttonLayout);
       buttonPane.set(
         {
           paddingTop: 11
         });
-      cellEditor.add(buttonPane, {row:5, column: 0, colSpan: 2});
+      cellEditor.add(buttonPane, {row:3, column: 0, colSpan: 2});
 
       // Retrieve the finite state machine
       fsm = cellInfo.table.getUserData("fsm");
 
+// Maybe OK button should be on left--not important ATM.
       var okButton =
         new qx.ui.form.Button("Ok", "icon/22/actions/dialog-ok.png");
+// Dont' understand next line
+// ( http://demo.qooxdoo.org/current/apiviewer/#qx.ui.core.Widget~addState doesn't say much )
       okButton.addState("default");
       fsm.addObject("ok", okButton);
       okButton.addListener("execute", fsm.eventListener, fsm);
@@ -227,6 +151,7 @@ qx.Class.define("aiagallery.module.mgmt.applications.CellEditorFactory",
       // The new row data was saved by the FSM. Retrieve it.
       var newData = cellEditor.getUserData("newData");
 
+// Not sure what the hell is going on here...
       // Return the appropriate column data.
       return newData[cellEditor.getUserData("cellInfo").col];
     }

--- a/frontend/aiagallery/source/class/aiagallery/module/mgmt/applications/CellEditorFactory.js
+++ b/frontend/aiagallery/source/class/aiagallery/module/mgmt/applications/CellEditorFactory.js
@@ -2,9 +2,9 @@
  * Cell editor for all cells of the Users table
  *
  * Copyright (c) 2011 Derrell Lipman
- * 
+ *
  * License:
- *   LGPL: http://www.gnu.org/licenses/lgpl.html 
+ *   LGPL: http://www.gnu.org/licenses/lgpl.html
  *   EPL : http://www.eclipse.org/org/documents/epl-v10.php
  */
 
@@ -47,7 +47,7 @@ qx.Class.define("aiagallery.module.mgmt.applications.CellEditorFactory",
         title = this.tr("Add New App");
         rowData = [ "", "", "", "", "", "", "", "", "" ];
       }
-      
+
       var layout = new qx.ui.layout.Grid(9, 2);
       layout.setColumnAlign(0, "right", "top");
       layout.setColumnWidth(0, 80);
@@ -100,15 +100,15 @@ qx.Class.define("aiagallery.module.mgmt.applications.CellEditorFactory",
       var displayName = new qx.ui.form.TextField("");
       displayName.setValue(rowData[0]);
       cellEditor.add(displayName, { row : 0, column : 1 });
-      
+
       // Create the editor field for the email address
       var email = new qx.ui.form.TextField("");
       email.setValue(rowData[1]);
       cellEditor.add(email, { row : 1, column : 1 });
-      
+
       // If we're editing, don't allow them to change the email (userId) value
       bEditing && email.setEnabled(false);
-      
+
       // Create the editor field for permissions
       var permissions = new qx.ui.form.List();
       permissions.setHeight(140);
@@ -119,8 +119,8 @@ qx.Class.define("aiagallery.module.mgmt.applications.CellEditorFactory",
 
       // Add each of the permission values
       qx.lang.Object.getKeys(aiagallery.dbif.Constants.Permissions).forEach(
-        function(perm) 
-        {          
+        function(perm)
+        {
           // Pull the permission description into the variable description
           var description = aiagallery.dbif.Constants.Permissions[perm];
 
@@ -130,18 +130,18 @@ qx.Class.define("aiagallery.module.mgmt.applications.CellEditorFactory",
           // Set the internal name of the permission to equal the display name
           item.setUserData("internal", perm);
 
-          // Set "description" in userdata of the permission to be the 
+          // Set "description" in userdata of the permission to be the
           // description of the permission.
-          item.setUserData("description", description); 
+          item.setUserData("description", description);
 
-          // Create a tooltip that describes the permission, then attach it to 
+          // Create a tooltip that describes the permission, then attach it to
           // the List Item
           var tooltip = new qx.ui.tooltip.ToolTip(description);
           item.setToolTip(tooltip);
 
           // Add the list item with the attached tool tip to the list
           permissions.add(item);
-          
+
           // Is this permission currently assigned to the user being edited?
           if (qx.lang.Array.contains(permissionList, perm))
           {
@@ -149,7 +149,7 @@ qx.Class.define("aiagallery.module.mgmt.applications.CellEditorFactory",
             permissions.addToSelection(item);
           }
         });
-      
+
       cellEditor.add(permissions, { row : 2, column : 1 });
 
       var status = new qx.ui.form.SelectBox();
@@ -161,26 +161,26 @@ qx.Class.define("aiagallery.module.mgmt.applications.CellEditorFactory",
         //  { i8n: this.tr("Active"),  internal: "Active" },
         //  { i8n: this.tr("Pending"), internal: "Pending" },
         //  { i8n: this.tr("Banned"),  internal: "Banned" }
-        //].forEach(function(stat) 
+        //].forEach(function(stat)
         {
           // Create a new list item with the current status' name
           var item = new qx.ui.form.ListItem(stat);
-          
+
           // Set the internal name of the status to the display name for now
           item.setUserData("internal", stat);
 
           // Add this item to the selectbox
           status.add(item);
-          
+
           // Is this the current status?
           if (stat == rowData[3])
           {
             status.setSelection( [ item ] );
           }
         });
-      
+
       cellEditor.add(status, { row : 3, column : 1 });
-      
+
       // Save the input fields for access by getCellEditorValue() and the FSM
       cellEditor.setUserData("displayName", displayName);
       cellEditor.setUserData("email", email);
@@ -225,7 +225,7 @@ qx.Class.define("aiagallery.module.mgmt.applications.CellEditorFactory",
     {
       // The new row data was saved by the FSM. Retrieve it.
       var newData = cellEditor.getUserData("newData");
-      
+
       // Return the appropriate column data.
       return newData[cellEditor.getUserData("cellInfo").col];
     }

--- a/frontend/aiagallery/source/class/aiagallery/module/mgmt/applications/Fsm.js
+++ b/frontend/aiagallery/source/class/aiagallery/module/mgmt/applications/Fsm.js
@@ -201,7 +201,7 @@ qx.Class.define("aiagallery.module.mgmt.applications.Fsm",
       state.addTransition(trans);
 
       /*
-       * Transition: Idle to AddOrEditUser
+       * Transition: Idle to AddOrEditApp
        *
        * Cause: "cellEditorOpening" on the Table. This can occur as a result
        * of either a press of the "Edit" button, or by double-clicking on the
@@ -212,9 +212,9 @@ qx.Class.define("aiagallery.module.mgmt.applications.Fsm",
        */
 
       trans = new qx.util.fsm.Transition(
-        "Transition_Idle_to_AddOrEditUser_via_cellEditorOpening",
+        "Transition_Idle_to_AddOrEditApp_via_cellEditorOpening",
       {
-        "nextState" : "State_AddOrEditUser",
+        "nextState" : "State_AddOrEditApp",
 
         "context" : this,
 

--- a/frontend/aiagallery/source/class/aiagallery/module/mgmt/applications/Fsm.js
+++ b/frontend/aiagallery/source/class/aiagallery/module/mgmt/applications/Fsm.js
@@ -7,7 +7,7 @@
  */
 
 /**
- * User management finite state machine
+ * Application management finite state machine
  */
 qx.Class.define("aiagallery.module.mgmt.applications.Fsm",
 {
@@ -107,10 +107,10 @@ qx.Class.define("aiagallery.module.mgmt.applications.Fsm",
       /*
        * Transition: Idle to AwaitRpcResult
        *
-       * Cause: "execute" on "Delete User" button
+       * Cause: "execute" on "Delete App" button
        *
        * Action:
-       *  Issue a remote procedure call to delete the selected user
+       *  Issue a remote procedure call to delete the selected app
        */
 
       trans = new qx.util.fsm.Transition(
@@ -128,7 +128,17 @@ qx.Class.define("aiagallery.module.mgmt.applications.Fsm",
           var table = fsm.getObject("table");
           var selectionModel = table.getSelectionModel();
           var selection = selectionModel.getSelectedRanges()[0].minIndex;
-          var data = table.getTableModel().getData()[selection];
+//          var data = table.getTableModel().getData()[selection];
+var data = table.getTableModel().getDataAsMapArray()[selection];
+// DEBUG:
+// Replaced getData with getDataAsMapArray in preceding line.
+// With this change, and the change to the Gui's getAppListAll handleResponse case (rememberMaps -> True),
+// we can now access the uid (as data.uid, not data[1]).
+// On sim data, there are a couple error messages because there's no apk blob, but the app's gone on reload.
+// NEXT STEPS: - Add more columns?
+//             - Implement cell editor
+//
+console.log("mgmt/apps--Transition_Idle_to_AwaitRpcResult_via_deleteApp -- data[]: " + qx.lang.Json.stringify(data));
 
           // Issue a Delete App call
           var request =
@@ -136,7 +146,8 @@ qx.Class.define("aiagallery.module.mgmt.applications.Fsm",
                           "aiagallery.features",
                           "deleteApp",
                           [
-                            data[1] // the email address is their user id
+//                            data[1] // ** NEED UID HERE! **
+data.uid
                           ]);
 
           // When we get the result, we'll need to know what type of request

--- a/frontend/aiagallery/source/class/aiagallery/module/mgmt/applications/Fsm.js
+++ b/frontend/aiagallery/source/class/aiagallery/module/mgmt/applications/Fsm.js
@@ -84,7 +84,7 @@ qx.Class.define("aiagallery.module.mgmt.applications.Fsm",
           // the event data.
           "callRpc" : "Transition_Idle_to_AwaitRpcResult_via_generic_rpc_call",
 
-          // When we get an appear event, retrieve the visitor list
+          // When we get an appear event, retrieve the application list
           "appear"    :
           {
             "main.canvas" : "Transition_Idle_to_AwaitRpcResult_via_appear"
@@ -125,18 +125,9 @@ qx.Class.define("aiagallery.module.mgmt.applications.Fsm",
           var table = fsm.getObject("table");
           var selectionModel = table.getSelectionModel();
           var selection = selectionModel.getSelectedRanges()[0].minIndex;
-//          var data = table.getTableModel().getData()[selection];
-var data = table.getTableModel().getDataAsMapArray()[selection];
-// DEBUG:
-// Replaced getData with getDataAsMapArray in preceding line.
-// With this change, and the change to the Gui's getAppListAll handleResponse case (rememberMaps -> True),
-// we can now access the uid (as data.uid, not data[1]).
-// On sim data, there are a couple error messages because there's no apk blob, but the app's gone on reload.
-// NEXT STEPS: - Add more columns?
-//             - Implement cell editor
-//
-console.log("mgmt/apps--Transition_Idle_to_AwaitRpcResult_via_deleteApp -- data[]: " + qx.lang.Json.stringify(data));
+          var data = table.getTableModel().getDataAsMapArray()[selection];
 
+//console.log("mgmt/apps--Transition_Idle_to_AwaitRpcResult_via_deleteApp -- data[]: " + qx.lang.Json.stringify(data));
           // Issue a Delete App call
           var request =
             this.callRpc(fsm,
@@ -222,7 +213,7 @@ console.log("mgmt/apps--Transition_Idle_to_AwaitRpcResult_via_deleteApp -- data[
       state.addTransition(trans);
 
       /*
-       * Transition: Idle to Idle
+       * Transition: Idle to AwaitRpcResult
        *
        * Cause: "appear" on canvas
        *
@@ -246,7 +237,12 @@ console.log("mgmt/apps--Transition_Idle_to_AwaitRpcResult_via_deleteApp -- data[
             this.callRpc(fsm,
                          "aiagallery.features",
                          "getAppListAll",
-                         [true, null, null, null, true]);
+// Superfluous 5th param?   ->  ->  ->  ->  ->  ->  vvvv
+//                         [true, null, null, null, true]);
+                         [true, null, null, null]);
+// Two issues:
+// - Should 1st param, bStringize, be true (as in mystuff) or null (as in myapps)?
+// - Less importantly--specify a default sortCriteria?
 
           // When we get the result, we'll need to know what type of request
           // we made.
@@ -391,8 +387,8 @@ console.log("mgmt/apps--Transition_Idle_to_AwaitRpcResult_via_deleteApp -- data[
           // Save the request data
           var requestData =
             {
-              titleField       : appTitle,
-              descriptionField : description
+              title       : appTitle,
+              description : description
             };
 
           // Issue an Add Or Edit Application call.

--- a/frontend/aiagallery/source/class/aiagallery/module/mgmt/applications/Fsm.js
+++ b/frontend/aiagallery/source/class/aiagallery/module/mgmt/applications/Fsm.js
@@ -1,8 +1,8 @@
 /**
  * Copyright (c) 2011 Derrell Lipman
- * 
+ *
  * License:
- *   LGPL: http://www.gnu.org/licenses/lgpl.html 
+ *   LGPL: http://www.gnu.org/licenses/lgpl.html
  *   EPL : http://www.eclipse.org/org/documents/epl-v10.php
  */
 
@@ -57,7 +57,7 @@ qx.Class.define("aiagallery.module.mgmt.applications.Fsm",
               rpcRequest.request = null;
             }
           }
-          
+
           // Be sure that edit and delete buttons enable status is correct
           var selectionModel = fsm.getObject("table").getSelectionModel();
           var bHasSelection = ! selectionModel.isSelectionEmpty();
@@ -142,7 +142,7 @@ qx.Class.define("aiagallery.module.mgmt.applications.Fsm",
           // When we get the result, we'll need to know what type of request
           // we made.
           request.setUserData("requestType", "deleteApp");
-          
+
           // We also need to know what row got deleted
           request.setUserData("deletedRow", selection);
         }
@@ -176,28 +176,28 @@ qx.Class.define("aiagallery.module.mgmt.applications.Fsm",
           // Get the cell editor factory for all columns of the table
           var cellEditorFactory =
             table.getTableColumnModel().getCellEditorFactory(0);
-          
+
           // Generate a simple cellInfo object
           var cellInfo = { table : table };
 
           // Get a cell editor
           cellEditor = cellEditorFactory.createCellEditor(cellInfo);
-          
+
           // Make it modal
           cellEditor.setModal(true);
-          
+
           // Disallow the window's close button
           cellEditor.setShowClose(false);
-          
+
           // Open the cell editor
           cellEditor.open();
-          
+
           // Save the cell editor and cell info
           this.setUserData("cellEditor", cellEditor);
           this.setUserData("cellInfo", cellInfo);
         }
       });
-        
+
       state.addTransition(trans);
 
       /*
@@ -223,13 +223,13 @@ qx.Class.define("aiagallery.module.mgmt.applications.Fsm",
           var data = event.getData();
           var cellEditor = data.cellEditor;
           var cellInfo = data.cellInfo;
-          
+
           // Save the cell editor and information of which row we're editing
           this.setUserData("cellEditor", cellEditor);
           this.setUserData("cellInfo", cellInfo);
         }
       });
-        
+
       state.addTransition(trans);
 
       /*
@@ -283,7 +283,7 @@ qx.Class.define("aiagallery.module.mgmt.applications.Fsm",
         "ontransition" : function(fsm, event)
         {
           // Issue the remote procedure call to get the application list.
-          // Request that the permissions and status be converted to strings 
+          // Request that the permissions and status be converted to strings
           // for us.
           var request =
             this.callRpc(fsm,
@@ -357,7 +357,7 @@ qx.Class.define("aiagallery.module.mgmt.applications.Fsm",
             // response objects.
             rpcRequest = this.popRpcRequest();
             response = rpcRequest.getUserData("rpc_response");
-            
+
             // Did it fail?
             if (response.type == "failed")
             {
@@ -369,7 +369,7 @@ qx.Class.define("aiagallery.module.mgmt.applications.Fsm",
             {
               // It succeeded. Resubmit the event to move us back to Idle
               fsm.eventListener(event);
-              
+
               // Push the RPC request back on the stack so it's available for
               // the next transition.
               this.pushRpcRequest(rpcRequest);
@@ -383,10 +383,10 @@ qx.Class.define("aiagallery.module.mgmt.applications.Fsm",
           {
             // When the Ok button is pressed in the cell editor
             "ok" : "Transition_AddOrEditApp_to_AwaitRpcResult_via_ok",
-            
+
             "cancel" : "Transition_AddOrEditApp_to_Idle_via_cancel"
           },
-          
+
           // When we received a "completed" event on RPC
           "completed" : "Transition_AddOrEditApp_to_Idle_via_completed"
         }
@@ -434,17 +434,17 @@ qx.Class.define("aiagallery.module.mgmt.applications.Fsm",
             {
               // Add to our permission list the "internal" (English) permission
               internal.permissions.push(item.getUserData("internal"));
-            
+
             });
           selection = cellEditor.getUserData("status").getSelection()[0];
           internal.status = selection.getUserData("internal");
-          
+
           // Save the request data
-          var requestData = 
+          var requestData =
             {
               displayName : displayName,
               permissions : internal.permissions,
-              status      : internal.status 
+              status      : internal.status
             };
 
           // Issue a Add Or Edit Application call.
@@ -494,16 +494,16 @@ qx.Class.define("aiagallery.module.mgmt.applications.Fsm",
           // Retrieve the cell editor and cell info
           cellEditor = this.getUserData("cellEditor");
           cellInfo = this.getUserData("cellInfo");
-          
+
           // Retrieve the table object
           var table = fsm.getObject("table");
-          
+
           // Tell the table we're no longer editing
           table.cancelEditing();
 
           // close the cell editor
           cellEditor.close();
-          
+
           // If we created this cell editor (cellInfo has only 'table')...
           if (typeof(cellInfo.row) == "undefined")
           {
@@ -551,7 +551,7 @@ qx.Class.define("aiagallery.module.mgmt.applications.Fsm",
 
           // Retrieve the RPC request
           rpcRequest = this.popRpcRequest();
-          
+
           // Get the cell editor and the request data from the RPC request
           cellEditor = this.getUserData("cellEditor");
           cellInfo = this.getUserData("cellInfo");
@@ -560,10 +560,10 @@ qx.Class.define("aiagallery.module.mgmt.applications.Fsm",
 
           // We'll also need the Table object, from the FSM
           table = fsm.getObject("table");
-          
+
           // Get the table's data model
           dataModel = table.getTableModel();
-          
+
           // Create the row data for the table
           rowData.push(requestData.displayName);
           rowData.push(requestData.email);
@@ -572,7 +572,7 @@ qx.Class.define("aiagallery.module.mgmt.applications.Fsm",
           // string, and add it it to the row data
           permissions = internal.permissions.join(", ");
           rowData.push(permissions);
-          
+
           // Add the status to the row data
           rowData.push(internal.status);
 
@@ -581,7 +581,7 @@ qx.Class.define("aiagallery.module.mgmt.applications.Fsm",
           {
             // ... then save the data in the row being edited.
             dataModel.setRows( [ rowData ], cellInfo.row, false);
-            
+
             // Save the data so that the cell editor's getCellEditorValue()
             // method can retrieve it.
             cellEditor.setUserData("newData", rowData);
@@ -591,10 +591,10 @@ qx.Class.define("aiagallery.module.mgmt.applications.Fsm",
             // Otherwise, add a new row. Do not clear sorting.
             dataModel.addRows( [ rowData ], null, false);
           }
-          
+
           // close the cell editor
           cellEditor.close();
-          
+
           // We can remove the cell editor and cell info from our own user
           // data now.
           this.setUserData("cellEditor", null);

--- a/frontend/aiagallery/source/class/aiagallery/module/mgmt/applications/Fsm.js
+++ b/frontend/aiagallery/source/class/aiagallery/module/mgmt/applications/Fsm.js
@@ -412,8 +412,7 @@ qx.Class.define("aiagallery.module.mgmt.applications.Fsm",
           // Issue an Add Or Edit Application call.
           request = this.callRpc(fsm,
                      "aiagallery.features",
-// Need new admin edit app feature!
-                     "addOrEditApp",
+                     "mgmtEditApp",
                      [ uid, requestData ]);
 
           // Save the user id in the request data too
@@ -424,8 +423,8 @@ qx.Class.define("aiagallery.module.mgmt.applications.Fsm",
 
           // When we get the result, we'll need to know what type of request
           // we made.
-// Fixme too.
-          request.setUserData("requestType", "AddOrEditApp");
+
+          request.setUserData("requestType", "mgmtEditApp");
 
 //          // Save the permissions and status
 //          request.setUserData("internal", internal);
@@ -573,10 +572,8 @@ qx.Class.define("aiagallery.module.mgmt.applications.Fsm",
 */
 
           // Put the data where it belongs. Preserve hidden data and sort order.
-          // Note: 'result' is an array with exactly one element, a map of
-          // app data, which is just what we need here.
 //          dataModel.setRowsAsMapArray( [ rowData ], cellInfo.row, true, false);
-          dataModel.setRowsAsMapArray(result, cellInfo.row, true, false);
+          dataModel.setRowsAsMapArray( [ result ] , cellInfo.row, true, false);
 // Might need to munge tags and status here!
 
           // Save the data so that the cell editor's getCellEditorValue()

--- a/frontend/aiagallery/source/class/aiagallery/module/mgmt/applications/Gui.js
+++ b/frontend/aiagallery/source/class/aiagallery/module/mgmt/applications/Gui.js
@@ -127,6 +127,31 @@ qx.Class.define("aiagallery.module.mgmt.applications.Gui",
             colSet  : { width : 50 }
           },
           {
+            heading : this.tr("Flags"),
+            id      : "numCurFlags",
+            colSet  : { width : 40 }
+          },
+          {
+            heading : this.tr("Views"),
+            id      : "numViewed",
+            colSet  : { width : 40 }
+          },
+          {
+            heading : this.tr("DLs"),
+            id      : "numDownloads",
+            colSet  : { width : 40 }
+          },
+          {
+            heading : this.tr("Likes"),
+            id      : "numLikes",
+            colSet  : { width : 40 }
+          },
+          {
+            heading : this.tr("Coms"),
+            id      : "numComments",
+            colSet  : { width : 40 }
+          },
+          {
             heading : this.tr("I1"),
             id      : "image1",
             colSet  : { width : 30 },

--- a/frontend/aiagallery/source/class/aiagallery/module/mgmt/applications/Gui.js
+++ b/frontend/aiagallery/source/class/aiagallery/module/mgmt/applications/Gui.js
@@ -248,11 +248,11 @@ qx.Class.define("aiagallery.module.mgmt.applications.Gui",
           // single-selection mode, so we can easily reference into the
           // selection array.
           var selection = selectionModel.getSelectedRanges()[0].minIndex;
-          var data = model.getData()[selection];
+          var data = model.getDataAsMapArray()[selection];
           var origEvent = e.clone();
 
           dialog.Dialog.confirm(
-            this.tr("Really delete app ") + data[2] + "?",
+            this.tr("Really delete app ") + data.title + "?",
             function(result)
             {
               // If they confirmed the deletion...
@@ -303,7 +303,11 @@ qx.Class.define("aiagallery.module.mgmt.applications.Gui",
         table = fsm.getObject("table");
 
         // Set the entire data model given the result array
-        table.getTableModel().setDataAsMapArray(response.data.result.apps);
+//        table.getTableModel().setDataAsMapArray(response.data.result.apps);
+table.getTableModel().setDataAsMapArray(response.data.result.apps, true, false);
+// DEBUG: Set 2nd parameter "rememberMaps" to true (from default of false).
+// When this change is made, columns not in the model become accessible (such as uid, e.g. when deleting an app)
+// (less important: 3rd param, "clearSorting", changed from T default to F so sorting preserved)
         break;
 
       case "addOrEditApp":

--- a/frontend/aiagallery/source/class/aiagallery/module/mgmt/applications/Gui.js
+++ b/frontend/aiagallery/source/class/aiagallery/module/mgmt/applications/Gui.js
@@ -24,8 +24,6 @@ qx.Class.define("aiagallery.module.mgmt.applications.Gui",
      */
     buildGui : function(module)
     {
-      var             o;
-      var             col;
       var             fsm = module.fsm;
       var             canvas = module.canvas;
       var             rowData;
@@ -85,6 +83,10 @@ qx.Class.define("aiagallery.module.mgmt.applications.Gui",
       // Generate a simple table model
       var model = new qx.ui.table.model.Simple();
 
+      // Column info.  Width parameters 1*, 2* indicate flex; see docs for
+      // qx.ui.table.columnmodel.resizebehavior.Default.setWidth()
+      // Re-titled image columns "Image <n>" to "I<n>", and widened 24 to 30 px,
+      // to make title visible.
       var columns =
         [
           {
@@ -125,21 +127,21 @@ qx.Class.define("aiagallery.module.mgmt.applications.Gui",
             colSet  : { width : 50 }
           },
           {
-            heading : this.tr("Image 1"),
+            heading : this.tr("I1"),
             id      : "image1",
-            colSet  : { width : 24 },
+            colSet  : { width : 30 },
             type    : "image"
           },
           {
-            heading : this.tr("Image 2"),
+            heading : this.tr("I2"),
             id      : "image2",
-            colSet  : { width : 24 },
+            colSet  : { width : 30 },
             type    : "image"
           },
           {
-            heading : this.tr("Image 3"),
+            heading : this.tr("I3"),
             id      : "image3",
-            colSet  : { width : 24 },
+            colSet  : { width : 30 },
             type    : "image"
           }
         ];
@@ -242,7 +244,7 @@ qx.Class.define("aiagallery.module.mgmt.applications.Gui",
         "execute",
         function(e)
         {
-          // Determine what user is selected for deletion. We're in
+          // Determine what app is selected for deletion. We're in
           // single-selection mode, so we can easily reference into the
           // selection array.
           var selection = selectionModel.getSelectedRanges()[0].minIndex;
@@ -250,8 +252,7 @@ qx.Class.define("aiagallery.module.mgmt.applications.Gui",
           var origEvent = e.clone();
 
           dialog.Dialog.confirm(
-            this.tr("Really delete user ") + data[1] +
-              " (" + data[0] + ")" + "?",
+            this.tr("Really delete app ") + data[2] + "?",
             function(result)
             {
               // If they confirmed the deletion...

--- a/frontend/aiagallery/source/class/aiagallery/module/mgmt/applications/Gui.js
+++ b/frontend/aiagallery/source/class/aiagallery/module/mgmt/applications/Gui.js
@@ -50,19 +50,6 @@ qx.Class.define("aiagallery.module.mgmt.applications.Gui",
       hBox.add(edit);
       fsm.addObject("edit", edit);
 
-      // Create an Add Application button
-      var addApp = new qx.ui.form.Button(this.tr("Add Application"));
-      addApp.set(
-        {
-          maxHeight : 24,
-          width     : 100
-        });
-      hBox.add(addApp);
-      addApp.addListener("execute", fsm.eventListener, fsm);
-
-      // We'll be receiving events on the object so save its friendly name
-      fsm.addObject("addApp", addApp, "main.fsmUtils.disable_during_rpc");
-
       // Now right-justify the Delete button
       hBox.add(new qx.ui.core.Widget(), { flex : 1 });
 

--- a/frontend/aiagallery/source/class/aiagallery/module/mgmt/applications/Gui.js
+++ b/frontend/aiagallery/source/class/aiagallery/module/mgmt/applications/Gui.js
@@ -320,6 +320,11 @@ qx.Class.define("aiagallery.module.mgmt.applications.Gui",
         // (3rd param "clearSorting", changed from T default to F so sorting preserved)
         table.getTableModel().setDataAsMapArray(response.data.result.apps, true, false);
         break;
+// Todo:  If no longer stringizing app rpc results, need to fix up status and tag displays
+//   both here, and when get rpc result from editing.
+// Maybe better idea:  Use special cell renderers
+//   qx.ui.table.cellrenderer.Replace looks tailor-made for that
+//   (use replaceMap for status and replaceFunction for arrays like tags)
 
       case "EditApp":
         // Nothing more to do but close the cell editor

--- a/frontend/aiagallery/source/class/aiagallery/module/mgmt/applications/Gui.js
+++ b/frontend/aiagallery/source/class/aiagallery/module/mgmt/applications/Gui.js
@@ -1,13 +1,13 @@
 /**
  * Copyright (c) 2011 Derrell Lipman
- * 
+ *
  * License:
- *   LGPL: http://www.gnu.org/licenses/lgpl.html 
+ *   LGPL: http://www.gnu.org/licenses/lgpl.html
  *   EPL : http://www.eclipse.org/org/documents/epl-v10.php
  */
 
 /**
- * The graphical user interface for application management 
+ * The graphical user interface for application management
  */
 qx.Class.define("aiagallery.module.mgmt.applications.Gui",
 {
@@ -61,7 +61,7 @@ qx.Class.define("aiagallery.module.mgmt.applications.Gui",
         });
       hBox.add(addApp);
       addApp.addListener("execute", fsm.eventListener, fsm);
-      
+
       // We'll be receiving events on the object so save its friendly name
       fsm.addObject("addApp", addApp, "main.fsmUtils.disable_during_rpc");
 
@@ -87,56 +87,56 @@ qx.Class.define("aiagallery.module.mgmt.applications.Gui",
 
       var columns =
         [
-          { 
+          {
             heading : this.tr("Owner"),
             id      : "owner",
             colSet  : { width : 90 }
           },
 
-          { 
+          {
             heading : this.tr("Email"),
             id      : "email",
             colSet  : { width : 90 }
           },
 
-          { 
+          {
             heading : this.tr("Display Name"),
             id      : "displayName",
             colSet  : { width : 90 }
           },
-          { 
+          {
             heading : this.tr("Title"),
             id      : "title",
             colSet  : { width : "1*" }
           },
-          { 
+          {
             heading : this.tr("Description"),
             id      : "description",
             colSet  : { width : "2*" }
           },
-          { 
+          {
             heading : this.tr("Tags"),
             id      : "tags",
             colSet  : { width : 120 }
           },
-          { 
+          {
             heading : this.tr("Status"),
             id      : "status",
             colSet  : { width : 50 }
           },
-          { 
+          {
             heading : this.tr("Image 1"),
             id      : "image1",
             colSet  : { width : 24 },
             type    : "image"
           },
-          { 
+          {
             heading : this.tr("Image 2"),
             id      : "image2",
             colSet  : { width : 24 },
             type    : "image"
           },
-          { 
+          {
             heading : this.tr("Image 3"),
             id      : "image3",
             colSet  : { width : 24 },
@@ -147,7 +147,7 @@ qx.Class.define("aiagallery.module.mgmt.applications.Gui",
       // Define the table columns
       model.setColumns(columns.map(function(elem)
                                    {
-                                     return elem.heading; 
+                                     return elem.heading;
                                    }),
                        columns.map(function(elem)
                                    {
@@ -164,7 +164,7 @@ qx.Class.define("aiagallery.module.mgmt.applications.Gui",
       // resizes columns.
       var custom =
       {
-        tableColumnModel : function(obj) 
+        tableColumnModel : function(obj)
         {
           return new qx.ui.table.columnmodel.Resize(obj);
         }
@@ -173,10 +173,10 @@ qx.Class.define("aiagallery.module.mgmt.applications.Gui",
       // Now that we have a data model, we can use it to create our table.
       var table = new aiagallery.widget.Table(model, custom);
       table.addListener("cellEditorOpening", fsm.eventListener, fsm);
-      
+
       // We'll be receiving events on the object so save its friendly name
       fsm.addObject("table", table, "main.fsmUtils.disable_during_rpc");
-      
+
       // Also save the FSM in the table, for access by cell editors
       table.setUserData("fsm", fsm);
 
@@ -195,10 +195,10 @@ qx.Class.define("aiagallery.module.mgmt.applications.Gui",
         {
           // Set the same cell editor factory for all columns
           tcm.setCellEditorFactory(col, editor);
-          
+
           // Apply the column-specific settings
           resizeBehavior.set(col, elem.colSet);
-          
+
           // If this is an image column...
           if (elem.type && elem.type == "image")
           {
@@ -250,7 +250,7 @@ qx.Class.define("aiagallery.module.mgmt.applications.Gui",
           var origEvent = e.clone();
 
           dialog.Dialog.confirm(
-            this.tr("Really delete user ") + data[1] + 
+            this.tr("Really delete user ") + data[1] +
               " (" + data[0] + ")" + "?",
             function(result)
             {
@@ -262,7 +262,7 @@ qx.Class.define("aiagallery.module.mgmt.applications.Gui",
               }
             });
         });
-      
+
       // Add the table to the page
       canvas.add(table, { flex : 1 });
     },
@@ -315,7 +315,7 @@ qx.Class.define("aiagallery.module.mgmt.applications.Gui",
         deletedRow = rpcRequest.getUserData("deletedRow");
         table.getTableModel().removeRows(deletedRow, 1, false);
         break;
-        
+
       default:
         throw new Error("Unexpected request type: " + requestType);
       }

--- a/frontend/aiagallery/source/class/aiagallery/module/mgmt/applications/Gui.js
+++ b/frontend/aiagallery/source/class/aiagallery/module/mgmt/applications/Gui.js
@@ -315,14 +315,13 @@ qx.Class.define("aiagallery.module.mgmt.applications.Gui",
         table = fsm.getObject("table");
 
         // Set the entire data model given the result array
-//        table.getTableModel().setDataAsMapArray(response.data.result.apps);
-table.getTableModel().setDataAsMapArray(response.data.result.apps, true, false);
-// DEBUG: Set 2nd parameter "rememberMaps" to true (from default of false).
-// When this change is made, columns not in the model become accessible (such as uid, e.g. when deleting an app)
-// (less important: 3rd param, "clearSorting", changed from T default to F so sorting preserved)
+        // 2nd parameter, "rememberMaps", set to true (default: false), so that
+        // columns not in the model are accessible (such as uid, e.g. when deleting an app)
+        // (3rd param "clearSorting", changed from T default to F so sorting preserved)
+        table.getTableModel().setDataAsMapArray(response.data.result.apps, true, false);
         break;
 
-      case "addOrEditApp":
+      case "EditApp":
         // Nothing more to do but close the cell editor
         break;
 


### PR DESCRIPTION
Done:
- Tweaked table display
- Implemented cell editor and fsm transitions so that title and description can be edited.
- Created mgmtEditApp rpc based on addOrEditApp used by myapps/mystuff.

To do:
- Add editing of tags, status, numCurFlags, more? (Can use tag code from old mystuff module)
- More work on mgmtEditApp rpc -- customization work from addOrEditApp not completed.
- Access should require admin permissions, not ownership.
- Fix bugs: 
- \- some fields not displayed on cell editor closing, but OK when module refreshed
- \- display of non-text fields in table needs tweaking
