### PR TITLE
Bug Fix for Duplicate "App" Tab Creation

### DIFF
--- a/frontend/aiagallery/source/class/aiagallery/main/Gui.js
+++ b/frontend/aiagallery/source/class/aiagallery/main/Gui.js
@@ -1291,10 +1291,14 @@ qx.Class.define("aiagallery.main.Gui",
         // so do nothing
         for (j = 0; j < pageArray.length; j++)
         {
-          if (pageArray[j].getLabel() == this.tr("App").toString())
+          if (pageArray[j].getUserData("app"))
           {
           
-            return; 
+            // Remove child from Page Selector
+            pageSelectorBar.remove(pageArray[j]); 
+          
+            // All done so break
+            break; 
           }
         }
           

--- a/frontend/aiagallery/source/class/aiagallery/main/Gui.js
+++ b/frontend/aiagallery/source/class/aiagallery/main/Gui.js
@@ -1275,6 +1275,20 @@ qx.Class.define("aiagallery.main.Gui",
         pageSelectorBar =
           aiagallery.main.Gui.getInstance().getUserData("pageSelectorBar");
           
+        // Get the children
+        pageArray = pageSelectorBar.getChildren();
+          
+        // Its possible we an app radio button page already exists if
+        // so do nothing
+        for (j = 0; j < pageArray.length; j++)
+        {
+          if (pageArray[j].getLabel() == this.tr("App").toString())
+          {
+          
+            return; 
+          }
+        }
+          
         // Create new temporary app radio button page
         tempRadioButton = new qx.ui.form.RadioButton(this.tr("App"));      
         tempRadioButton.set(
@@ -1285,9 +1299,6 @@ qx.Class.define("aiagallery.main.Gui",
           
         //Add to children a new temporary App Page
         pageSelectorBar.add(tempRadioButton);
-        
-        // Get the children
-        pageArray = pageSelectorBar.getChildren();
                  
         //Select it  
         pageSelectorBar.setSelection([pageArray[pageArray.length - 1]]);


### PR DESCRIPTION
This a bug fix. When a user is in an "App" tab and then clicks to go into another app an additional "App Tab" label is created and added to the pageSelector. This fix prevents that behavior. 
