### PR TITLE
Fix Issue 74

### DIFF
--- a/frontend/aiagallery/source/class/aiagallery/main/Gui.js
+++ b/frontend/aiagallery/source/class/aiagallery/main/Gui.js
@@ -1457,6 +1457,9 @@ qx.Class.define("aiagallery.main.Gui",
     {
       var             parts;
       var             components;
+      
+      // Ensure fragment is properly decoded
+      fragment = decodeURIComponent(fragment); 
 
       // Is this an app page or find apps search?
       parts = fragment.split("&"); 


### PR DESCRIPTION
In order to have bookmarks be loaded correctly on entry into AIG we must ensure that the URL is decoded correctly. It appears in Chrome and IE that the url was not being decoded correctly on entry into AIG. This fix should resolve issue #74. 
