### PR TITLE
Canonicalize Field

### DIFF
--- a/backend-appengine/war/WEB-INF/appengine-generated/datastore-indexes-auto.xml
+++ b/backend-appengine/war/WEB-INF/appengine-generated/datastore-indexes-auto.xml
@@ -1,4 +1,4 @@
-<!-- Indices written at Tue, 10 Apr 2012 22:59:26 UTC -->
+<!-- Indices written at Wed, 11 Apr 2012 20:27:47 UTC -->
 
 <datastore-indexes/>
 

--- a/backend-appengine/war/WEB-INF/appengine-generated/datastore-indexes-auto.xml
+++ b/backend-appengine/war/WEB-INF/appengine-generated/datastore-indexes-auto.xml
@@ -1,4 +1,4 @@
-<!-- Indices written at Wed, 11 Apr 2012 20:27:47 UTC -->
+<!-- Indices written at Wed, 11 Apr 2012 20:47:48 UTC -->
 
 <datastore-indexes/>
 

--- a/dbif/source/class/aiagallery/dbif/MVisitors.js
+++ b/dbif/source/class/aiagallery/dbif/MVisitors.js
@@ -495,7 +495,7 @@ qx.Mixin.define("aiagallery.dbif.MVisitors",
       var              criteria;
       
       // Ensure name is within length range
-      if(name.length <= 5 || name.length > 30)
+      if(name.length < 5 || name.length > 30)
       {
         // Name is not valid return error
         error.setCode(2);

--- a/dbif/source/class/aiagallery/dbif/ObjVisitors.js
+++ b/dbif/source/class/aiagallery/dbif/ObjVisitors.js
@@ -102,6 +102,7 @@ qx.Class.define("aiagallery.dbif.ObjVisitors",
     // Register our property types
     aiagallery.dbif.Entity.registerPropertyTypes("visitors",
                                                  databaseProperties,
-                                                 "id");
+                                                 "id",
+                                                 canonicalize);
   }
 });

--- a/dbif/source/class/aiagallery/dbif/ObjVisitors.js
+++ b/dbif/source/class/aiagallery/dbif/ObjVisitors.js
@@ -76,7 +76,29 @@ qx.Class.define("aiagallery.dbif.ObjVisitors",
         /** Timestamp of last connection */
         "connectionTimestamp" : "Date"
       };
+      
+    var canonicalize = 
+      {
+        "displayName" :
+        {
+          // Property in which to store the canonical value. Since we are
+          // converting the value to lower case, we'll give the property a
+          // name that reflects that.
+          prop : "displayName_lc",
+          
+          // The canonical value will be a string
+          type : "String",
 
+          // Function to convert a value to lower case
+          func : function(value)
+          {
+            return (typeof value == "undefined" || value === null
+                    ? null
+                    : value.toLowerCase());
+          }
+        }
+      };
+      
     // Register our property types
     aiagallery.dbif.Entity.registerPropertyTypes("visitors",
                                                  databaseProperties,


### PR DESCRIPTION
Canonicalize the displayName field in ObjVisitor and fix a minor error where the code checking the length of the display name was not in agreement with the actual requirements. 
