### PR TITLE
Fix Issue 98: Single-character description crashes app

### DIFF
--- a/dbif/source/class/aiagallery/dbif/MApps.js
+++ b/dbif/source/class/aiagallery/dbif/MApps.js
@@ -169,7 +169,7 @@ qx.Mixin.define("aiagallery.dbif.MApps",
         case "title":
         case "description":
           // Split up the words and...
-          wordsToAdd = dataObj[appDataField].match(acceptable_word);
+          wordsToAdd = dataObj[appDataField].match(acceptable_word) || [];
           wordsToAdd.forEach(function(word)
               {
                 // Make sure to only add lower case words to the search


### PR DESCRIPTION
Crashed on null.forEach(...) when no word matches.  Replaced with [].
